### PR TITLE
Tweaked variable name to match clowder's config

### DIFF
--- a/clowder/clowder.json
+++ b/clowder/clowder.json
@@ -42,7 +42,7 @@
             "canOverride": false
         },
         {
-            "name": "TOOLMGR_URI",
+            "name": "TOOLMANAGER_URI",
             "value": "localhost:8082",
             "label": "ToolServer address",
             "canOverride": true

--- a/clowder/clowder.json
+++ b/clowder/clowder.json
@@ -43,7 +43,7 @@
         },
         {
             "name": "TOOLMANAGER_URI",
-            "value": "localhost:8082",
+            "value": "http://localhost:8082",
             "label": "ToolServer address",
             "canOverride": true
         }


### PR DESCRIPTION
In the proposed https://opensource.ncsa.illinois.edu/bitbucket/projects/CATS/repos/clowder/pull-requests/781/overview, Clowder is setting this variable name to be TOOLMANAGER_URI.
