### PR TITLE
NDS-132 Support Dataverse/iRODS integration

### DIFF
--- a/clowder/clowder.json
+++ b/clowder/clowder.json
@@ -51,7 +51,7 @@
     "ports": [
         {
             "port": 9000,
-            "protocol": "TCP"
+            "protocol": "http"
         }
     ]
 }

--- a/clowder/elastic.json
+++ b/clowder/elastic.json
@@ -6,7 +6,7 @@
     "isService": true,
     "isStandalone": false,
     "ports": [
-        { "port": 9300, "protocol": "TCP" }
+        { "port": 9300, "protocol": "tcp" }
     ],
     "args" : [
         "-Des.cluster.name=clowder" 

--- a/clowder/mongo.json
+++ b/clowder/mongo.json
@@ -8,8 +8,8 @@
     "isStandalone": true,
     "requiresVolume": true,
     "ports": [
-        { "port": 27017, "protocol": "TCP" },
-        { "port": 28017, "protocol": "TCP" }
+        { "port": 27017, "protocol": "tcp" },
+        { "port": 28017, "protocol": "tcp" }
     ],
     "volumeMounts":[
         { "mountPath": "/data/db", "name": "mongo" }

--- a/clowder/mongo.json
+++ b/clowder/mongo.json
@@ -8,8 +8,7 @@
     "isStandalone": true,
     "requiresVolume": true,
     "ports": [
-        { "port": 27017, "protocol": "tcp" },
-        { "port": 28017, "protocol": "tcp" }
+        { "port": 27017, "protocol": "tcp" }
     ],
     "volumeMounts":[
         { "mountPath": "/data/db", "name": "mongo" }

--- a/clowder/rabbitmq.json
+++ b/clowder/rabbitmq.json
@@ -7,8 +7,8 @@
     "isService": true,
     "isStandalone": false,
     "ports": [
-        { "port": 5672, "protocol": "TCP" },
-        { "port": 15672, "protocol": "TCP" }
+        { "port": 5672, "protocol": "tcp" },
+        { "port": 15672, "protocol": "tcp" }
     ]
 }
 

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -17,7 +17,7 @@
     "depends": [
       { "key": "postgres", "required": true },
       { "key": "solr", "required": true },
-      { "key": "rserve", "required": false},
+      { "key": "rserve", "required": true},
       { "key": "tworavens", "required": false },
       { "key": "dvicat", "required": false }
     ],

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -11,7 +11,7 @@
     "ports": [
         {
             "port": 8080,
-            "protocol": "TCP"
+            "protocol": "http"
         }
     ],
     "depends": [
@@ -26,56 +26,65 @@
             "name": "MAIL_SERVER",
             "value": "smtp.ncsa.illinois.edu",
             "label": "SMTP server",
-            "canOverride": true
+            "canOverride": true,
+            "service": "dataverse"
         },
         {
             "name": "POSTGRES_DATABASE",
             "value": "dvndb",
-            "canOverride": false
+            "canOverride": false,
+            "service": "postgres"
         },
         {
             "name": "POSTGRES_USER",
             "value": "dvnapp",
-            "canOverride": false
+            "canOverride": false,
+            "service": "postgres"
         },
         {
             "name": "POSTGRES_PASSWORD",
             "value": "",
             "label": "Database password",
             "canOverride": true,
-            "isPassword": true
+            "isPassword": true,
+            "service": "postgres"
         },
         {
             "name": "RSERVE_USER",
             "value": "rserve",
-            "canOverride": false
+            "canOverride": false,
+            "service": "rserve"
         },
         {
             "name": "RSERVE_PASSWORD",
             "value": "rserve",
             "label": "RServe password",
-            "canOverride": false
+            "canOverride": false,
+            "service": "rserve"
         },
         {
             "name": "IRODS_ZONE",
             "value": "dvnZone",
             "label": "iRODS Zone",
             "canOverride": true,
-            "isPassword": false
+            "isPassword": false,
+            "service": "dvicat"
         },
         {
             "name": "IRODS_USER",
             "value": "dataverse",
             "label": "iRODS rods user",
             "canOverride": true,
-            "isPassword": false
+            "isPassword": false,
+            "service": "dvicat"
         },
         {
             "name": "IRODS_PASSWORD",
             "value": "",
             "label": "iRODS user password",
             "canOverride": true,
-            "isPassword": true
+            "isPassword": true,
+            "service": "dvicat"
         }
     ],
 	"volumeMounts":[

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -2,7 +2,7 @@
     "key": "dataverse",
     "label": "Dataverse",
       "requiresVolume": true,
-    "image": "ndslabs/dataverse:dev",
+    "image": "ndslabs/dataverse:latest",
     "isService": true,
     "isStack": true,
     "isPublic": true,

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -10,7 +10,7 @@
     "description": "A web application to share, preserve, cite, explore and analyze research data",
     "ports": [
         {
-            "port": 8080
+            "port": 8080,
             "protocol": "http"
         }
     ],

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -1,16 +1,16 @@
 {
     "key": "dataverse",
     "label": "Dataverse",
-  	"requiresVolume": true,
+      "requiresVolume": true,
     "image": "ndslabs/dataverse:dev",
     "isService": true,
     "isStack": true,
-	"isPublic": true,
-	"isStandalone": true,
-	"description": "A web application to share, preserve, cite, explore and analyze research data",
+    "isPublic": true,
+    "isStandalone": true,
+    "description": "A web application to share, preserve, cite, explore and analyze research data",
     "ports": [
         {
-            "port": 8080,
+            "port": 8080
             "protocol": "http"
         }
     ],
@@ -19,7 +19,7 @@
       { "key": "solr", "required": true },
       { "key": "rserve", "required": true},
       { "key": "tworavens", "required": false },
-      { "key": "dvicat", "required": false }
+      { "key": "dvicat", "required": false, "shareConfig": true }
     ],
     "config":  [
         {
@@ -55,36 +55,15 @@
             "value": "rserve",
             "label": "RServe password",
             "canOverride": false
-        },
-        {
-            "name": "IRODS_ZONE",
-            "value": "dvnZone",
-            "label": "iRODS Zone",
-            "canOverride": true,
-            "isPassword": false
-        },
-        {
-            "name": "IRODS_USER",
-            "value": "dataverse",
-            "label": "iRODS rods user",
-            "canOverride": true,
-            "isPassword": false
-        },
-        {
-            "name": "IRODS_PASSWORD",
-            "value": "",
-            "label": "iRODS user password",
-            "canOverride": true,
-            "isPassword": true
         }
     ],
-	"volumeMounts":[
-	   { "mountPath": "/usr/local/glassfish4/glassfish/domains/domain1/files", "name": "dataverse" }
+    "volumeMounts":[
+       { "mountPath": "/usr/local/glassfish4/glassfish/domains/domain1/files", "name": "dataverse" }
     ], 
-	"readinessProbe" : {
-		"path" : "/resources/images/dataverseproject_logo.jpg",
-		"port" : 8080,
-		"initialDelay": 30,
-		"timeout" : 600
-	}
+    "readinessProbe" : {
+        "path" : "/resources/images/dataverseproject_logo.jpg",
+        "port" : 8080,
+        "initialDelay": 30,
+        "timeout" : 600
+    }
 }

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -29,11 +29,32 @@
             "canOverride": true
         },
         {
+            "name": "POSTGRES_DATABASE",
+            "value": "dvndb",
+            "canOverride": false
+        },
+        {
+            "name": "POSTGRES_USER",
+            "value": "dvnapp",
+            "canOverride": false
+        },
+        {
             "name": "POSTGRES_PASSWORD",
             "value": "",
             "label": "Database password",
             "canOverride": true,
             "isPassword": true
+        },
+        {
+            "name": "RSERVE_USER",
+            "value": "rserve",
+            "canOverride": false
+        },
+        {
+            "name": "RSERVE_PASSWORD",
+            "value": "rserve",
+            "label": "RServe password",
+            "canOverride": false
         },
         {
             "name": "IRODS_ZONE",
@@ -44,15 +65,15 @@
         },
         {
             "name": "IRODS_USER",
-            "value": "rods",
-            "label": "iRODS rods user password",
+            "value": "dataverse",
+            "label": "iRODS rods user",
             "canOverride": true,
             "isPassword": false
         },
         {
             "name": "IRODS_PASSWORD",
             "value": "",
-            "label": "iRODS rods user password",
+            "label": "iRODS user password",
             "canOverride": true,
             "isPassword": true
         }

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -2,7 +2,7 @@
     "key": "dataverse",
     "label": "Dataverse",
   	"requiresVolume": true,
-    "image": "ndslabs/dataverse:latest",
+    "image": "ndslabs/dataverse:dev",
     "isService": true,
     "isStack": true,
 	"isPublic": true,
@@ -17,35 +17,16 @@
     "depends": [
       { "key": "postgres", "required": true },
       { "key": "solr", "required": true },
-      { "key": "rserve", "required": true},
-      { "key": "tworavens", "required": false }
+      { "key": "rserve", "required": false},
+      { "key": "tworavens", "required": false },
+      { "key": "dvicat", "required": false }
     ],
     "config":  [
-        {
-            "name": "HOST_DNS_ADDRESS",
-            "value": "localhost",
-            "canOverride": false
-        },
-        {
-            "name": "GLASSFISH_DIRECTORY",
-            "value": "/usr/local/glassfish4",
-            "canOverride": false
-        },
         {
             "name": "MAIL_SERVER",
             "value": "smtp.ncsa.illinois.edu",
             "label": "SMTP server",
             "canOverride": true
-        },
-        {
-            "name": "POSTGRES_DATABASE",
-            "value": "dvndb",
-            "canOverride": false
-        },
-        {
-            "name": "POSTGRES_USER",
-            "value": "dvnapp",
-            "canOverride": false
         },
         {
             "name": "POSTGRES_PASSWORD",
@@ -55,34 +36,8 @@
             "isPassword": true
         },
         {
-            "name": "RSERVE_USER",
-            "value": "rserve",
-            "canOverride": false
-        },
-        {
-            "name": "RSERVE_PASSWORD",
-            "value": "",
-            "label": "RServe password",
-            "canOverride": true,
-            "isPassword": true
-        },
-        {
-            "name": "IRODS_PORT",
-            "value": "1247",
-            "label": "iRODS server post",
-            "canOverride": true,
-            "isPassword": false
-        },
-        {
-            "name": "IRODS_ADDRESS",
-            "value": "",
-            "label": "iRODS server host",
-            "canOverride": true,
-            "isPassword": false
-        },
-        {
             "name": "IRODS_ZONE",
-            "value": "tempZone",
+            "value": "dvnZone",
             "label": "iRODS Zone",
             "canOverride": true,
             "isPassword": false

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -26,65 +26,56 @@
             "name": "MAIL_SERVER",
             "value": "smtp.ncsa.illinois.edu",
             "label": "SMTP server",
-            "canOverride": true,
-            "service": "dataverse"
+            "canOverride": true
         },
         {
             "name": "POSTGRES_DATABASE",
             "value": "dvndb",
-            "canOverride": false,
-            "service": "postgres"
+            "canOverride": false
         },
         {
             "name": "POSTGRES_USER",
             "value": "dvnapp",
-            "canOverride": false,
-            "service": "postgres"
+            "canOverride": false
         },
         {
             "name": "POSTGRES_PASSWORD",
             "value": "",
             "label": "Database password",
             "canOverride": true,
-            "isPassword": true,
-            "service": "postgres"
+            "isPassword": true
         },
         {
             "name": "RSERVE_USER",
             "value": "rserve",
-            "canOverride": false,
-            "service": "rserve"
+            "canOverride": false
         },
         {
             "name": "RSERVE_PASSWORD",
             "value": "rserve",
             "label": "RServe password",
-            "canOverride": false,
-            "service": "rserve"
+            "canOverride": false
         },
         {
             "name": "IRODS_ZONE",
             "value": "dvnZone",
             "label": "iRODS Zone",
             "canOverride": true,
-            "isPassword": false,
-            "service": "dvicat"
+            "isPassword": false
         },
         {
             "name": "IRODS_USER",
             "value": "dataverse",
             "label": "iRODS rods user",
             "canOverride": true,
-            "isPassword": false,
-            "service": "dvicat"
+            "isPassword": false
         },
         {
             "name": "IRODS_PASSWORD",
             "value": "",
             "label": "iRODS user password",
             "canOverride": true,
-            "isPassword": true,
-            "service": "dvicat"
+            "isPassword": true
         }
     ],
 	"volumeMounts":[

--- a/dataverse/dvicat.json
+++ b/dataverse/dvicat.json
@@ -64,7 +64,7 @@
             "isPassword": false
         }
     ],
-	"volumeMounts":[
-	   { "mountPath": "/var/lib/irods/iRODS/Vault", "name": "dvicat" }
+    "volumeMounts":[
+       { "mountPath": "/var/lib/irods/iRODS/Vault", "name": "dvicat" }
     ]
 }

--- a/dataverse/dvicat.json
+++ b/dataverse/dvicat.json
@@ -10,7 +10,7 @@
     "ports": [
         {
             "port": 1247,
-            "protocol": "TCP"
+            "protocol": "tcp"
         }
     ],
     "config":  [

--- a/dataverse/dvicat.json
+++ b/dataverse/dvicat.json
@@ -16,7 +16,7 @@
     "config":  [
         {
             "name": "RODS_ZONE",
-            "value": "",
+            "value": "dvnZone",
             "label": "iRODS local zone",
             "canOverride": true,
             "isPassword": false
@@ -37,7 +37,7 @@
         },
         {
             "name": "PRESERVATION_ZONE",
-            "value": "",
+            "value": "fedZone",
             "label": "iRODS preservation zone",
             "canOverride": true,
             "isPassword": false

--- a/dataverse/dvicat.json
+++ b/dataverse/dvicat.json
@@ -5,7 +5,7 @@
     "isService": true,
     "isStandalone": false,
     "isStack": false ,
-    "isPublic": false,
+    "isPublic": true,
     "requiresVolume": true,
     "ports": [
         {

--- a/dataverse/dvicat.json
+++ b/dataverse/dvicat.json
@@ -1,7 +1,7 @@
 {
     "key": "dvicat",
     "label": "Dataverse iRODS iCAT",
-    "image": "ndslabs/dataverse-icat:dev",
+    "image": "ndslabs/dataverse-icat:latest",
     "isService": true,
     "isStandalone": false,
     "isStack": false ,

--- a/dataverse/dvicat.json
+++ b/dataverse/dvicat.json
@@ -1,0 +1,70 @@
+{
+    "key": "dvicat",
+    "label": "Dataverse iRODS iCAT",
+    "image": "ndslabs/dataverse-icat:dev",
+    "isService": true,
+    "isStandalone": false,
+    "isStack": false ,
+    "isPublic": false,
+    "requiresVolume": true,
+    "ports": [
+        {
+            "port": 1247,
+            "protocol": "TCP"
+        }
+    ],
+    "config":  [
+        {
+            "name": "RODS_ZONE",
+            "value": "",
+            "label": "iRODS local zone",
+            "canOverride": true,
+            "isPassword": false
+        },
+        {
+            "name": "PRESERVATION_USER",
+            "value": "dataverse",
+            "label": "iRODS user",
+            "canOverride": true,
+            "isPassword": false
+        },
+        {
+            "name": "PRESERVATION_PASSWORD",
+            "value": "",
+            "label": "iRODS password",
+            "canOverride": true,
+            "isPassword": true
+        },
+        {
+            "name": "PRESERVATION_ZONE",
+            "value": "",
+            "label": "iRODS preservation zone",
+            "canOverride": true,
+            "isPassword": false
+        },
+        {
+            "name": "PRESERVATION_SERVER",
+            "value": "nds-irods-demo",
+            "label": "iRODS preservation server hostname",
+            "canOverride": true,
+            "isPassword": false
+        },
+        {
+            "name": "PRESERVATION_SERVER_IP",
+            "value": "",
+            "label": "iRODS preservation server IP",
+            "canOverride": true,
+            "isPassword": false
+        },
+        {
+            "name": "PRESERVATION_SERVER_PORT",
+            "value": "1247",
+            "label": "iRODS preservation server port",
+            "canOverride": true,
+            "isPassword": false
+        }
+    ],
+	"volumeMounts":[
+	   { "mountPath": "/var/lib/irods/iRODS/Vault", "name": "dvicat" }
+    ]
+}

--- a/dataverse/postgres.json
+++ b/dataverse/postgres.json
@@ -7,7 +7,7 @@
     "requiresVolume": true,
     "image": "postgres:9.3",
     "ports": [
-        { "port": 5432, "protocol": "TCP" }
+        { "port": 5432, "protocol": "tcp" }
     ],
     "volumeMounts":[
         { "mountPath": "/var/lib/postgresql/data", "name": "postgres" }

--- a/dataverse/rserve.json
+++ b/dataverse/rserve.json
@@ -6,6 +6,6 @@
     "label": "Rserve",
     "image": "ndslabs/dataverse-rserve:latest",
     "ports": [
-        { "port": 6311, "protocol": "TCP" }
+        { "port": 6311, "protocol": "tcp" }
     ]
 }

--- a/dataverse/solr.json
+++ b/dataverse/solr.json
@@ -12,5 +12,11 @@
     ],
     "volumeMounts":[
         { "mountPath": "/usr/local/solr-4.6.0/example/solr/collection1/data", "name": "solr" }
-    ]
+    ],
+    "readinessProbe" : {
+        "path" : "/solr",
+        "port" : 8983,
+        "initialDelay": 30,
+        "timeout" : 600
+    }
 }

--- a/dataverse/solr.json
+++ b/dataverse/solr.json
@@ -8,7 +8,7 @@
     "requiresVolume": true,
     "image": "ndslabs/dataverse-solr:latest",
     "ports": [
-        { "port": 8983, "protocol": "TCP" }
+        { "port": 8983, "protocol": "http" }
     ],
     "volumeMounts":[
         { "mountPath": "/usr/local/solr-4.6.0/example/solr/collection1/data", "name": "solr" }

--- a/dataverse/tworavens.json
+++ b/dataverse/tworavens.json
@@ -8,6 +8,6 @@
     "label": "TwoRavens",
     "image": "ndslabs/tworavens:latest",
     "ports": [
-        { "port": 80, "protocol": "TCP" }
+        { "port": 80, "protocol": "http" }
     ]
 }

--- a/elk/elastic.json
+++ b/elk/elastic.json
@@ -8,7 +8,7 @@
     "isStandalone": true,
     "requiresVolume": true,
     "ports": [
-        { "port": 9200, "protocol": "TCP" }
+        { "port": 9200, "protocol": "tcp" }
     ],
     "volumeMounts":[
         { "mountPath": "/usr/share/elasticsearch/data", "name": "elasticsearch2" }

--- a/elk/kibana.json
+++ b/elk/kibana.json
@@ -1,7 +1,7 @@
 {
     "key": "kibana",
     "label": "Kibana (ELK)",
-    "image": "kibana",
+    "image": "kibana:4.4",
     "description": "An open source data visualization platform",
     "isStack": true,
     "isService": true,

--- a/elk/kibana.json
+++ b/elk/kibana.json
@@ -22,7 +22,7 @@
         }
     ],
     "ports": [
-        { "port": 5601, "protocol": "TCP" }
+        { "port": 5601, "protocol": "tcp" }
     ],
     "config":  [
         {

--- a/elk/logstash.json
+++ b/elk/logstash.json
@@ -12,7 +12,7 @@
     "label": "Logstash",
     "image": "logstash",
     "ports": [
-        { "port": 5000, "protocol": "TCP" }
+        { "port": 5000, "protocol": "tcp" }
     ],
     "command": [ "logstash", "-e" ],
     "args" : [ "output { elasticsearch { hosts => \"$(ELASTICSEARCH2_PORT_9200_TCP_ADDR):$(ELASTICSEARCH2_PORT_9200_TCP_PORT)\" } } input { tcp { port => 5000 type => syslog } }" ]

--- a/elk/logstash.json
+++ b/elk/logstash.json
@@ -10,7 +10,7 @@
     "isService": true,
     "isStandalone": false,
     "label": "Logstash",
-    "image": "logstash",
+    "image": "logstash:2.2",
     "ports": [
         { "port": 5000, "protocol": "tcp" }
     ],

--- a/irods/cloudbrowser.json
+++ b/irods/cloudbrowser.json
@@ -10,7 +10,7 @@
     "ports": [
         {
             "port": 8009,
-            "protocol": "TCP"
+            "protocol": "http"
         }
     ],
     "config":  [

--- a/irods/cloudbrowser.json
+++ b/irods/cloudbrowser.json
@@ -2,7 +2,7 @@
     "key": "cloudbrowser",
     "label": "iRODS Cloudbrowser API",
     "requiresVolume": false,
-    "image": "ndslabs/cloudbrowser:latest",
+    "image": "ndslabs/cloudbrowser:dev",
     "isService": true,
     "isStandalone": false,
     "isStack": false,
@@ -16,7 +16,7 @@
     "config":  [
         {
             "name": "IRODS_ZONE",
-            "value": "fedZone",
+            "value": "",
             "label": "iRODS Zone",
             "canOverride": true
         }

--- a/irods/cloudbrowser.json
+++ b/irods/cloudbrowser.json
@@ -2,7 +2,7 @@
     "key": "cloudbrowser",
     "label": "iRODS Cloudbrowser API",
     "requiresVolume": false,
-    "image": "ndslabs/cloudbrowser:dev",
+    "image": "ndslabs/cloudbrowser:latest",
     "isService": true,
     "isStandalone": false,
     "isStack": false,

--- a/irods/cloudbrowser.json
+++ b/irods/cloudbrowser.json
@@ -16,7 +16,7 @@
     "config":  [
         {
             "name": "IRODS_ZONE",
-            "value": "tempZone",
+            "value": "fedZone",
             "label": "iRODS Zone",
             "canOverride": true
         }

--- a/irods/cloudbrowserui.json
+++ b/irods/cloudbrowserui.json
@@ -2,7 +2,7 @@
     "key": "cloudbrowserui",
     "label": "iRODS Cloudbrowser UI",
     "requiresVolume": false,
-    "image": "ndslabs/cloudbrowser-ui:dev",
+    "image": "ndslabs/cloudbrowser-ui:latest",
     "isService": true,
     "isStandalone": true,
     "isStack": false,

--- a/irods/cloudbrowserui.json
+++ b/irods/cloudbrowserui.json
@@ -15,5 +15,11 @@
     ],
     "depends": [
       { "key": "cloudbrowser", "required": true }
-    ]
+    ],
+    "readinessProbe" : {
+        "path" : "app/images/beta_test_logo.png",
+        "port" : 80,
+        "initialDelay": 30,
+        "timeout" : 600
+    }
 }

--- a/irods/cloudbrowserui.json
+++ b/irods/cloudbrowserui.json
@@ -2,7 +2,7 @@
     "key": "cloudbrowserui",
     "label": "iRODS Cloudbrowser UI",
     "requiresVolume": false,
-    "image": "ndslabs/cloudbrowser-ui:latest",
+    "image": "ndslabs/cloudbrowser-ui:dev",
     "isService": true,
     "isStandalone": true,
     "isStack": false,
@@ -10,7 +10,7 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "TCP"
+            "protocol": "http"
         }
     ],
     "depends": [

--- a/irods/icat.json
+++ b/irods/icat.json
@@ -10,11 +10,11 @@
     "ports": [
         {
             "port": 1247,
-            "protocol": "TCP"
+            "protocol": "tcp"
         },
         {
             "port": 8080,
-            "protocol": "TCP"
+            "protocol": "http"
         }
     ],
     "config":  [

--- a/irods/icat.json
+++ b/irods/icat.json
@@ -2,7 +2,7 @@
     "key": "icat",
     "label": "iRODS iCAT",
     "requiresVolume": true,
-    "image": "ndslabs/irods-icat:4.1.3",
+    "image": "ndslabs/irods-icat:dev",
     "isService": true,
     "isStandalone": true,
     "isStack": true,
@@ -11,12 +11,16 @@
         {
             "port": 1247,
             "protocol": "TCP"
+        },
+        {
+            "port": 8080,
+            "protocol": "TCP"
         }
     ],
     "config":  [
         {
             "name": "RODS_ZONE",
-            "value": "tempZone",
+            "value": "fedZone",
             "label": "iRODS zone",
             "canOverride": true
         },

--- a/irods/icat.json
+++ b/irods/icat.json
@@ -2,7 +2,7 @@
     "key": "icat",
     "label": "iRODS iCAT",
     "requiresVolume": true,
-    "image": "ndslabs/irods-icat:dev",
+    "image": "ndslabs/irods-icat:latest",
     "isService": true,
     "isStandalone": true,
     "isStack": true,


### PR DESCRIPTION
Added Dataverse iCAT (dvicat spec) with changes to Dataverse and iRODS services to support the Dataverse-preservation workflow. Also updated protocols.
