### PR TITLE
Add LaTiS Server Test

### DIFF
--- a/latis/README.md
+++ b/latis/README.md
@@ -1,0 +1,41 @@
+# LaTiS Server Test
+
+For some information about LaTiS (and some out-dated code), see https://github.com/dlindhol/LaTiS.
+
+After launching this service in NDS Labs, you can use the LaTiS web service API to access an El Nino related index dataset. This LaTiS server instance uses an XML descriptor to **model** a portion of the data source at ftp://ftp.cpc.ncep.noaa.gov/wd52dg/data/indices/sstoi.indices as a LaTiS dataset. In this case I chose to expose the data as a time series (i.e. a **function** of time) of the "Sea Surface Temperature Index - Optimum Interpolation" indices "nino12", "nino3", "nino4", and "nino34".
+
+```
+  time -> (nino12, nino3, nino4, nino34)
+```
+
+The LaTiS server implements the OPeNDAP (DAP2) specification yet does far more than the typical OPeNDAP server. To get some basic usage information (with lots of rough edges) for this specific instance, see
+
+```
+  http://ip:port/latis-nds/latis/
+```
+
+To get the full El Nino index dataset (sstoi_indices) in a CSV format:
+
+```
+  http://ip:port/latis-nds/latis/sstoi_indices.csv
+```
+
+Or in JSON format:
+
+```
+  http://ip:port/latis-nds/latis/sstoi_indices.json
+```
+
+Or just nino34 for this year with a different time format:
+
+```
+  http://ip:port/latis-nds/latis/sstoi_indices.json?time,nino34&time>=2016&format_time(MMM yyyy)
+```
+
+LaTiS even models its own log files as a dataset:
+
+```
+  http://ip:port/latis-nds/latis/log.txt
+```
+
+More to come.

--- a/latis/README.md
+++ b/latis/README.md
@@ -2,6 +2,8 @@
 
 For some information about LaTiS (and some out-dated code), see https://github.com/dlindhol/LaTiS.
 
+The code for this LaTiS instance can be found at https://github.com/dlindhol/latis-nds. 
+
 After launching this service in NDS Labs, you can use the LaTiS web service API to access an El Nino related index dataset. This LaTiS server instance uses an XML descriptor to **model** a portion of the data source at ftp://ftp.cpc.ncep.noaa.gov/wd52dg/data/indices/sstoi.indices as a LaTiS dataset. In this case I chose to expose the data as a time series (i.e. a **function** of time) of the "Sea Surface Temperature Index - Optimum Interpolation" indices "nino12", "nino3", "nino4", and "nino34".
 
 ```

--- a/latis/latis-nds.json
+++ b/latis/latis-nds.json
@@ -1,0 +1,11 @@
+{
+    "key": "latis",
+    "label": "LaTiS",
+    "image": "dlindhol/latis-nds:latest",
+    "description": "Sample LaTiS data server instance to explore NDS Labs possibilities",
+    "access": "external",
+    "display": "stack",
+    "ports": [
+        { "port": 8080, "protocol": "http" }
+    ]
+}


### PR DESCRIPTION
I created a docker image that contains a LaTiS data server instance running in Jetty. I was able to get it running in the ndslabs VM that we used in the NDS5 workshop with this spec. I added a smattering of documentation and there's a bit of cruft lying about, but I figured we had to start somewhere.
