### PR TITLE
NDS-326 / NDS-328 / NDS-340: Added specs for Cloud9 (C/C+, Node.js, and Go)

### DIFF
--- a/devenvs/cloud9-cpp.json
+++ b/devenvs/cloud9-cpp.json
@@ -1,0 +1,30 @@
+{
+    "key": "cloud9cpp",
+    "label": "Cloud9 C/C++",
+    "image": "ndslabs/cloud9-cpp",
+    "display": "stack",
+    "access": "external",
+    "description": "Unopinionated C/C++ development environment based on Cloud9",
+    "ports": [
+        {
+            "port": 80,
+            "protocol": "http"
+        }
+    ],
+    "volumeMounts":[
+       { "mountPath": "/workspace", "name": "cloud9cpp" }
+    ],
+    "readinessProbe" : {
+        "type" : "http",
+        "path" : "/favicon.ico",
+        "port" : 80,
+        "initialDelay": 10,
+        "timeout" : 600
+    },
+    "resourceLimits": {
+        "cpuMax": "1",
+        "cpuDefault": "100m",
+        "memMax": "1Gi",
+        "memDefault": "50Mi"
+    }
+}

--- a/devenvs/cloud9-go.json
+++ b/devenvs/cloud9-go.json
@@ -1,0 +1,30 @@
+{
+    "key": "cloud9go",
+    "label": "Cloud9 GO",
+    "image": "ndslabs/cloud9-go",
+    "display": "stack",
+    "access": "external",
+    "description": "Unopinionated Go development environment based on Cloud9",
+    "ports": [
+        {
+            "port": 80,
+            "protocol": "http"
+        }
+    ],
+    "volumeMounts":[
+       { "mountPath": "/workspace", "name": "cloud9go" }
+    ],
+    "readinessProbe" : {
+        "type" : "http",
+        "path" : "/favicon.ico",
+        "port" : 80,
+        "initialDelay": 10,
+        "timeout" : 600
+    },
+    "resourceLimits": {
+        "cpuMax": "1",
+        "cpuDefault": "100m",
+        "memMax": "1Gi",
+        "memDefault": "50Mi"
+    }
+}

--- a/devenvs/cloud9-nodejs.json
+++ b/devenvs/cloud9-nodejs.json
@@ -1,0 +1,30 @@
+{
+    "key": "cloud9nodejs",
+    "label": "Cloud9 Node.js",
+    "image": "ndslabs/cloud9-nodejs",
+    "display": "stack",
+    "access": "external",
+    "description": "Unopinionated Node.js development environment based on Cloud9",
+    "ports": [
+        {
+            "port": 80,
+            "protocol": "http"
+        }
+    ],
+    "volumeMounts":[
+       { "mountPath": "/workspace", "name": "cloud9nodejs" }
+    ],
+    "readinessProbe" : {
+        "type" : "http",
+        "path" : "/favicon.ico",
+        "port" : 80,
+        "initialDelay": 10,
+        "timeout" : 600
+    },
+    "resourceLimits": {
+        "cpuMax": "1",
+        "cpuDefault": "100m",
+        "memMax": "1Gi",
+        "memDefault": "50Mi"
+    }
+}


### PR DESCRIPTION
See:
- https://opensource.ncsa.illinois.edu/jira/browse/NDS-326
- https://opensource.ncsa.illinois.edu/jira/browse/NDS-328
- https://opensource.ncsa.illinois.edu/jira/browse/NDS-340
