### PR TITLE
Clowder changed its base repo name

### DIFF
--- a/clowder/clowder.json
+++ b/clowder/clowder.json
@@ -3,8 +3,8 @@
     "key": "clowder",
     "description": "A scalable data repository where you can share, organize and analyze data.",
     "image": {
-	"name": "ncsa/clowder",
-	"tags" : ["1.0", "0.9.5", "0.9.4.2", "0.9.4.1", "0.9.4", "0.9.3", "0.9.2", "latest"]
+	"name": "clowder/clowder",
+	"tags" : ["1.1.1", "1.0.1", "1.0", "0.9.5", "0.9.4.2", "0.9.4.1", "0.9.4", "latest"]
     },
     "display": "stack",
     "access": "external",

--- a/clowder/extractors/audio-preview.json
+++ b/clowder/extractors/audio-preview.json
@@ -3,7 +3,7 @@
     "label": "Audio Preview Extractor",
     "description": "Clowder extractor for audio preview clips",
     "image": {
-		"name": "ncsa/clowder-extractors-audio-preview", 
+		"name": "ncsa/extractors-audio-preview", 
 		"tags" : ["latest"]
 	},
     "access": "internal",

--- a/clowder/extractors/audio-preview.json
+++ b/clowder/extractors/audio-preview.json
@@ -3,7 +3,7 @@
     "label": "Audio Preview Extractor",
     "description": "Clowder extractor for audio preview clips",
     "image": {
-		"name": "ncsa/extractors-audio-preview", 
+		"name": "clowder/extractors-audio-preview", 
 		"tags" : ["latest"]
 	},
     "access": "internal",

--- a/clowder/extractors/digest.json
+++ b/clowder/extractors/digest.json
@@ -3,7 +3,7 @@
     "label": "Message Digest (MD5) Extractor",
     "description": "Clowder extractor for generating MD5 hashes of uploaded files",
     "image": {
-		"name": "ncsa/clowder-extractors-digest", 
+		"name": "clowder/extractors-digest", 
 		"tags" : ["latest"]
 	},
 	"access": "internal",

--- a/clowder/extractors/image-metadata.json
+++ b/clowder/extractors/image-metadata.json
@@ -3,7 +3,7 @@
     "label": "Image Metadata Extractor",
     "description": "Clowder extractor for image metadata",
     "image": {
-        "name": "ncsa/clowder-extractors-image-metadata", 
+        "name": "ncsa/extractors-image-metadata", 
         "tags" : ["latest"]
     },
     "access": "internal",

--- a/clowder/extractors/image-metadata.json
+++ b/clowder/extractors/image-metadata.json
@@ -3,7 +3,7 @@
     "label": "Image Metadata Extractor",
     "description": "Clowder extractor for image metadata",
     "image": {
-        "name": "ncsa/extractors-image-metadata", 
+        "name": "clowder/extractors-image-metadata", 
         "tags" : ["latest"]
     },
     "access": "internal",

--- a/clowder/extractors/image-preview.json
+++ b/clowder/extractors/image-preview.json
@@ -3,7 +3,7 @@
     "label": "Image Preview Extractor",
     "description": "Clowder extractor for image preview thumbnails",
     "image": {
-		"name": "ncsa/clowder-extractors-image-preview", 
+		"name": "clowder/extractors-image-preview", 
 		"tags" : ["latest"]
 	},
 	"access": "internal",

--- a/clowder/extractors/office-preview.json
+++ b/clowder/extractors/office-preview.json
@@ -3,7 +3,7 @@
     "label": "Office Preview Extractor",
     "description": "Clowder extractor for creating previews of OpenOffice documents",
     "image": {
-		"name": "ncsa/clowder-extractors-office-preview", 
+		"name": "clowder/extractors-office-preview", 
 		"tags" : ["latest"]
 	},
 	"access": "internal",

--- a/clowder/extractors/pdf-preview.json
+++ b/clowder/extractors/pdf-preview.json
@@ -3,7 +3,7 @@
     "label": "PDF Preview Extractor",
     "description": "Clowder extractor for PDF preview thumbnails",
     "image": {
-		"name": "ncsa/clowder-extractors-pdf-preview", 
+		"name": "clowder/extractors-pdf-preview", 
 		"tags" : ["latest"]
 	},
     "access": "internal",

--- a/clowder/extractors/video-preview.json
+++ b/clowder/extractors/video-preview.json
@@ -3,7 +3,7 @@
     "label": "Video Preview Extractor",
     "description": "Clowder extractor for creating a series of preview shots from a video",
     "image": {
-		"name": "ncsa/clowder-extractors-video-preview", 
+		"name": "clowder/extractors-video-preview", 
 		"tags" : ["latest"]
 	},
 	"access": "internal",


### PR DESCRIPTION
In an e-mail from Rob:
```
All,

Luigi and I spend some time cleaning up the docker repositories. We removed all repositories in ncsa organization, if your code uses FROM: ncsa/ you will need to change it.

If you use pyclowder you will need to use: FROM clowder/pyclowder:1, if you use pyclowder 2 you will need to use FROM: clowder/pyclowder:2

Rob
```

The only images that are not affected are the following:
* speech2text extractor
* plantcv extractor
* pyCharm for pyClowder