### PR TITLE
NDS-623: Many specs with HTTP ports are missing context paths

### DIFF
--- a/clowder/clowder-pycharm-xpra.json
+++ b/clowder/clowder-pycharm-xpra.json
@@ -16,7 +16,8 @@
     "ports": [
         {
             "port": 10000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "depends": [

--- a/clowder/clowder.json
+++ b/clowder/clowder.json
@@ -85,7 +85,8 @@
     "ports": [
         {
             "port": 9000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "resourceLimits": {

--- a/dataverse/dataverse.json
+++ b/dataverse/dataverse.json
@@ -12,7 +12,8 @@
     "ports": [
         {
             "port": 8080,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "depends": [

--- a/dataverse/dvicat.json
+++ b/dataverse/dvicat.json
@@ -11,7 +11,8 @@
     "ports": [
         {
             "port": 1247,
-            "protocol": "tcp"
+            "protocol": "tcp",
+            "contextPath": "/"
         }
     ],
     "config":  [

--- a/dataverse/rserve.json
+++ b/dataverse/rserve.json
@@ -9,7 +9,7 @@
 		"tags": ["4.2.3", "latest"]
 	},
     "ports": [
-        { "port": 6311, "protocol": "tcp" }
+        { "port": 6311, "protocol": "tcp", "contextPath": "/" }
     ],
     "resourceLimits": {
         "cpuMax": 200,

--- a/dataverse/solr.json
+++ b/dataverse/solr.json
@@ -9,7 +9,7 @@
 		"tags": ["4.2.3", "latest"]
 	},
     "ports": [
-        { "port": 8983, "protocol": "http" }
+        { "port": 8983, "protocol": "http", "contextPath": "/" }
     ],
     "volumeMounts":[
         { "mountPath": "/usr/local/solr-4.6.0/example/solr/collection1/data" }

--- a/dataverse/tworavens.json
+++ b/dataverse/tworavens.json
@@ -11,7 +11,7 @@
 		"tags": ["latest", "4.2.3"]
 	},
     "ports": [
-        { "port": 80, "protocol": "http" }
+        { "port": 80, "protocol": "http", "contextPath": "/" }
     ],
     "resourceLimits": {
         "cpuMax": 200,

--- a/devenvs/cloud9-cpp.json
+++ b/devenvs/cloud9-cpp.json
@@ -12,7 +12,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts":[

--- a/devenvs/cloud9-docker.json
+++ b/devenvs/cloud9-docker.json
@@ -12,7 +12,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts":[

--- a/devenvs/cloud9-go.json
+++ b/devenvs/cloud9-go.json
@@ -12,7 +12,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts":[

--- a/devenvs/cloud9-java.json
+++ b/devenvs/cloud9-java.json
@@ -12,7 +12,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts":[

--- a/devenvs/cloud9-nodejs.json
+++ b/devenvs/cloud9-nodejs.json
@@ -12,7 +12,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts":[

--- a/devenvs/cloud9-php.json
+++ b/devenvs/cloud9-php.json
@@ -12,7 +12,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts":[

--- a/devenvs/cloud9-python.json
+++ b/devenvs/cloud9-python.json
@@ -13,7 +13,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts":[

--- a/devenvs/pycharm-xpra.json
+++ b/devenvs/pycharm-xpra.json
@@ -13,7 +13,8 @@
     "ports": [
         {
             "port": 10000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts": [

--- a/devenvs/vimpy.json
+++ b/devenvs/vimpy.json
@@ -13,7 +13,8 @@
     "ports": [
         {
             "port": 3000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "volumeMounts":[

--- a/docker/docker.json
+++ b/docker/docker.json
@@ -12,7 +12,8 @@
     "ports": [
         {
             "port": 3000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "display": "stack",

--- a/dspace/dspace.json
+++ b/dspace/dspace.json
@@ -58,7 +58,8 @@
     "ports": [
         {
             "port": 8080,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/elasticsearch/elastic.json
+++ b/elasticsearch/elastic.json
@@ -10,7 +10,7 @@
 	},
 	"access": "internal",
     "ports": [
-        { "port": 9300, "protocol": "tcp", "contextPath": "/" }
+        { "port": 9300, "protocol": "tcp" }
     ],
     "args" : [
         "-Des.cluster.name=clowder" 

--- a/elasticsearch/elastic.json
+++ b/elasticsearch/elastic.json
@@ -10,7 +10,7 @@
 	},
 	"access": "internal",
     "ports": [
-        { "port": 9300, "protocol": "tcp" }
+        { "port": 9300, "protocol": "tcp", "contextPath": "/" }
     ],
     "args" : [
         "-Des.cluster.name=clowder" 

--- a/fedora/commons.json
+++ b/fedora/commons.json
@@ -20,7 +20,8 @@
     "ports": [
         {
             "port": 8080,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/girder/girder.json
+++ b/girder/girder.json
@@ -26,7 +26,8 @@
   "ports": [
     {
       "port": 8080,
-      "protocol": "http"
+      "protocol": "http",
+      "contextPath": "/"
     }
   ],
   "repositories": [

--- a/hydra/hydra.json
+++ b/hydra/hydra.json
@@ -39,7 +39,8 @@
     "ports": [
         {
             "port": 3000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "readinessProbe": {

--- a/hydra/sufia.json
+++ b/hydra/sufia.json
@@ -66,7 +66,8 @@
     "ports": [
         {
             "port": 3000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "readinessProbe": {

--- a/iqvoc/iqvoc.json
+++ b/iqvoc/iqvoc.json
@@ -14,7 +14,8 @@
     "ports": [
         {
             "port": 3000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/irods/cloudbrowserui.json
+++ b/irods/cloudbrowserui.json
@@ -13,7 +13,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "depends": [

--- a/irods/icat.json
+++ b/irods/icat.json
@@ -16,7 +16,8 @@
         },
         {
             "port": 8080,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "config":  [

--- a/jenkins/jenkins.json
+++ b/jenkins/jenkins.json
@@ -17,7 +17,8 @@
     "ports": [
         {
             "port": 8080,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         },
         {
             "port": 50000,

--- a/jupyter/dsnotebook.json
+++ b/jupyter/dsnotebook.json
@@ -23,7 +23,8 @@
     "ports": [
         {
             "port": 8888,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": null,

--- a/jupyter/jupyterlab.json
+++ b/jupyter/jupyterlab.json
@@ -14,7 +14,8 @@
     "ports": [
         {
             "port": 8888,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/jupyter/minimal.json
+++ b/jupyter/minimal.json
@@ -23,7 +23,8 @@
     "ports": [
         {
             "port": 8888,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/ontowiki/ontowiki.json
+++ b/ontowiki/ontowiki.json
@@ -16,7 +16,8 @@
     "ports": [
         {
             "port": 80,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/protege/webprotege.json
+++ b/protege/webprotege.json
@@ -20,7 +20,8 @@
     "ports": [
         {
             "port": 8080,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/redis/redis.json
+++ b/redis/redis.json
@@ -16,7 +16,8 @@
     "ports": [
         {
             "port": 6379,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "readinessProbe": {

--- a/rstudio/rstudio.json
+++ b/rstudio/rstudio.json
@@ -15,7 +15,8 @@
     "ports": [
         {
             "port": 8787,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/solr/solr6.json
+++ b/solr/solr6.json
@@ -31,7 +31,8 @@
     "ports": [
         {
             "port": 8983,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "readinessProbe": {

--- a/system/chisel.json
+++ b/system/chisel.json
@@ -23,7 +23,8 @@
     "ports": [
         {
             "port": 8080,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": [

--- a/system/cloudcmd.json
+++ b/system/cloudcmd.json
@@ -19,7 +19,8 @@
     "ports": [
         {
             "port": 8000,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "readinessProbe": {

--- a/toolserver/toolserver.json
+++ b/toolserver/toolserver.json
@@ -17,7 +17,8 @@
     "ports": [
         {
             "port": 8082,
-            "protocol": "http"
+            "protocol": "http",
+            "contextPath": "/"
         }
     ],
     "repositories": null,


### PR DESCRIPTION
Update all HTTP specs to include a context path of "/", where appropriate

See https://opensource.ncsa.illinois.edu/jira/browse/NDS-623