### PR TITLE
NDS-1106 Add spec for MDF Forge Notebook

### DIFF
--- a/mdf/forge-notebook.json
+++ b/mdf/forge-notebook.json
@@ -1,0 +1,57 @@
+{
+    "key": "forge",
+    "label": "Forge",
+    "description": "Materials Data Facility Forge",
+    "logo": "https://s3.amazonaws.com/ndslabs/ForgeIcon.png",
+    "image": {
+        "name": "bengal1/forge-notebook",
+        "tags": [
+            "latest"
+        ]
+    },
+    "display": "stack",
+    "access": "external",
+    "config": [
+        {
+            "name": "PASSWORD",
+            "value": "",
+            "label": "Password",
+            "isPassword": true,
+            "canOverride": false
+        }
+    ],
+    "ports": [
+        {
+            "port": 8888,
+            "protocol": "http",
+            "contextPath": "/"
+        }
+    ],
+    "repositories": [
+		{
+			"type": "git",
+			"url" : "https://github.com/jupyter/notebook"
+		}
+	],
+    "readinessProbe": {
+        "type": "http",
+        "path": "/static/base/images/favicon.ico",
+        "port": 8888,
+        "initialDelay": 5,
+        "timeout": 600
+    },
+    "volumeMounts": [
+		{
+			"mountPath": "/home/jovyan/work"
+		}
+    ],
+    "resourceLimits": {
+        "cpuMax": 500,
+        "cpuDefault": 100,
+        "memMax": 1000,
+        "memDefault": 50
+    },
+	"developerEnvironment" : "cloud9nodejs",
+    "info" : "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Jupyter+Notebooks",
+    "tags": ["7", "21", "20", "28"]
+}

--- a/mdf/forge-notebook.json
+++ b/mdf/forge-notebook.json
@@ -4,7 +4,7 @@
     "description": "Materials Data Facility Forge",
     "logo": "https://s3.amazonaws.com/ndslabs/ForgeIcon.png",
     "image": {
-        "name": "bengal1/forge-notebook",
+        "name": "ndslabs/forge-notebook",
         "tags": [
             "latest"
         ]


### PR DESCRIPTION
# Problem
The Materials Data Facility Forge application is a python library used to leverage the MDF Data Discovery service. We need to make it available to users through workbench.

# Approach
* Create a Docker image based on the scipy-notebook and push to Docker Hub
* Add a new spec to this repo that depends on this image

# How to test
* Copy the JSON from `forge-notebook.json` into a new application in Workbench
* Launch
* Follow along with examples from the [forge repo](https://github.com/materials-data-facility/forge).
