### PR TITLE
Add globus personal connect spec

### DIFF
--- a/globus/README.md
+++ b/globus/README.md
@@ -1,0 +1,12 @@
+# Globus Connect Personal Endpoint
+This application starts up a personal Globus endpoint with data served out
+of the user's home directory.
+
+## Setup
+Before the application can be launched, the user must acquire a Globus endpoint
+setup key by visiting [https://www.globus.org/app/endpoints/create-gcp](https://www.globus.org/app/endpoints/create-gcp). The generated key should be copied and pasted into the application's
+`SETUP_KEY` property value.
+
+Once this is done just launch the application. After the application reports
+_Ready_ the endpoint is active and users can initiate transfers to and from the
+using the Globus [_Transfer Files_](https://www.globus.org/app/transfer) page.

--- a/globus/globuspersonal.json
+++ b/globus/globuspersonal.json
@@ -18,7 +18,7 @@
       }
     ],
     "display": "stack",
-    "access": "external",
+    "access": "internal",
     "repositories": [
         {
             "url": "https://github.com/nds-org/gcp-docker",
@@ -27,7 +27,7 @@
     ],
     "volumeMounts": [
         {
-            "mountPath": "/data",
+            "mountPath": "/globusdata",
             "defaultPath":"/"
         }
     ],
@@ -43,6 +43,6 @@
         "20",
         "28"
     ],
-    "info": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Jupyter+Notebooks",
-    "authRequired": true
+    "info": "https://github.com/nds-org/ndslabs-specs/blob/globus/globus/README.md",
+    "authRequired": false
 }

--- a/globus/globuspersonal.json
+++ b/globus/globuspersonal.json
@@ -1,0 +1,48 @@
+{
+    "key": "globusconnect",
+    "label": "Globus Connect",
+    "description": "Launch a Globus Endpoint",
+    "logo": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR4okBXwGGU3GEKEfTCRNuZW_geJCArj8k_T5r_7Iq4bUPZEVPMUg",
+    "image": {
+        "registry": "",
+        "name": "ndslabs/gcp-docker",
+        "tags": [
+            "latest"
+        ]
+    },
+    "config": [
+      {
+        "name": "SETUP_KEY",
+        "value": "",
+        "canOverride": true
+      }
+    ],
+    "display": "stack",
+    "access": "external",
+    "repositories": [
+        {
+            "url": "https://github.com/nds-org/gcp-docker",
+            "type": "git"
+        }
+    ],
+    "volumeMounts": [
+        {
+            "mountPath": "/data",
+            "defaultPath":"/"
+        }
+    ],
+    "resourceLimits": {
+        "cpuMax": 2000,
+        "cpuDefault": 100,
+        "memMax": 2000,
+        "memDefault": 50
+    },
+    "tags": [
+        "7",
+        "21",
+        "20",
+        "28"
+    ],
+    "info": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Jupyter+Notebooks",
+    "authRequired": true
+}

--- a/globus/globuspersonalconnect.json
+++ b/globus/globuspersonalconnect.json
@@ -1,0 +1,48 @@
+{
+    "key": "globusconnectpersonal",
+    "label": "Globus Connect",
+    "description": "Launch a Globus Endpoint",
+    "logo": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR4okBXwGGU3GEKEfTCRNuZW_geJCArj8k_T5r_7Iq4bUPZEVPMUg",
+    "image": {
+        "registry": "",
+        "name": "ndslabs/gcp-docker",
+        "tags": [
+            "latest"
+        ]
+    },
+    "config": [
+      {
+        "name": "SETUP_KEY",
+        "value": "",
+        "canOverride": true
+      }
+    ],
+    "display": "stack",
+    "access": "external",
+    "repositories": [
+        {
+            "url": "https://github.com/nds-org/gcp-docker",
+            "type": "git"
+        }
+    ],
+    "volumeMounts": [
+        {
+            "mountPath": "/data",
+            "defaultPath":"/"
+        }
+    ],
+    "resourceLimits": {
+        "cpuMax": 2000,
+        "cpuDefault": 100,
+        "memMax": 2000,
+        "memDefault": 50
+    },
+    "tags": [
+        "7",
+        "21",
+        "20",
+        "28"
+    ],
+    "info": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Jupyter+Notebooks",
+    "authRequired": true
+}


### PR DESCRIPTION
# Problem
Need to be able to run a personal Globus endpoint inside of workbench 

# Approach 
Extended Meissnert's [gcp-docker](https://github.com/meissnert/gcp-docker) image to make it standalone. You pass in the SETUP_KEY as an environment variable and mount a volume into /data and it starts up the endpoint automatically. This is done in an nds-labs [fork](https://github.com/nds-org/gcp-docker/tree/command_line) and auto builds a [docker hub image](https://hub.docker.com/r/ndslabs/gcp-docker/) - `ndslabs-gcp-docker`.

I created a new spec which uses this image and exposes and environment variable where the user can supply the `SETUP_KEY`. Full instructions on using the spec are in the README found in this commit. 