### PR TITLE
NDS-1116: Disabled token auth

### DIFF
--- a/jupyter/dsnotebook.json
+++ b/jupyter/dsnotebook.json
@@ -11,15 +11,13 @@
     },
     "display": "stack",
     "access": "external",
-    "config": [
-        {
-            "name": "PASSWORD",
-            "value": "",
-            "label": "Password",
-            "isPassword": true,
-            "canOverride": false
-        }
+    "command": [
+        "start-notebook.sh"
     ],
+    "args": [
+        "--NotebookApp.token=''"
+    ],
+    "authRequired": true,
     "ports": [
         {
             "port": 8888,

--- a/jupyter/jupyterlab.json
+++ b/jupyter/jupyterlab.json
@@ -11,13 +11,13 @@
     },
     "display": "stack",
     "access": "external",
-    "ports": [
-        {
-            "port": 8888,
-            "protocol": "http",
-            "contextPath": "/"
-        }
+    "command": [
+        "start-notebook.sh"
     ],
+    "args": [
+        "--NotebookApp.token=''"
+    ],
+    "authRequired": true,
     "repositories": [
 		{
 			"type": "git",

--- a/jupyter/minimal.json
+++ b/jupyter/minimal.json
@@ -11,15 +11,13 @@
     },
     "display": "stack",
     "access": "external",
-    "config": [
-        {
-            "name": "PASSWORD",
-            "value": "",
-            "label": "Password",
-            "isPassword": true,
-            "canOverride": false
-        }
+    "command": [
+        "start-notebook.sh"
     ],
+    "args": [
+        "--NotebookApp.token=''"
+    ],
+	"authRequired": true,
     "ports": [
         {
             "port": 8888,


### PR DESCRIPTION
Our Jupyter specs currently run default images that use the token auth method.  I've disabled to run using Workbench auth. This will be used for testing NDS-1116.