### PR TITLE
NDS-1233 Add Forge notebook with globus auth

### DIFF
--- a/globus/forgeglobus.json
+++ b/globus/forgeglobus.json
@@ -1,0 +1,61 @@
+{
+    "key": "forgeglobus",
+    "label": "Forge with Globus",
+    "description": "Materials Data Facility Forge",
+    "logo": "https://s3.amazonaws.com/ndslabs/ForgeIcon.png",
+    "image": {
+        "registry": "",
+        "name": "ndslabs/forge-notebook",
+        "tags": [
+            "globus"
+        ]
+    },
+    "display": "stack",
+    "access": "external",
+    "config": [
+        {
+            "name": "PASSWORD",
+            "label": "Password",
+            "isPassword": true
+        }
+    ],
+    "ports": [
+        {
+            "port": 8888,
+            "protocol": "http",
+            "contextPath": "/"
+        }
+    ],
+    "repositories": [
+        {
+            "url": "https://github.com/jupyter/notebook",
+            "type": "git"
+        }
+    ],
+    "readinessProbe": {
+        "type": "http",
+        "path": "/static/base/images/favicon.ico",
+        "port": 8888,
+        "initialDelay": 5,
+        "timeout": 600
+    },
+    "volumeMounts": [
+        {
+            "mountPath": "/home/jovyan/work"
+        }
+    ],
+    "resourceLimits": {
+        "cpuMax": 500,
+        "cpuDefault": 100,
+        "memMax": 1000,
+        "memDefault": 50
+    },
+    "developerEnvironment": "cloud9nodejs",
+    "tags": [
+        "7",
+        "21",
+        "20",
+        "28"
+    ],
+    "info": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/Jupyter+Notebooks"
+}


### PR DESCRIPTION
# Problem
The Forge library uses the Globus SDK to force the user to visit a url to obtain a key to access resources. Now that we have globus auth in workbench we need to be able to load keys from the user's home directory and use them automatically.

# Approach
Created a fork of the forge.py to add a new argument to the Forge constructor. This spec uses that special build of the fork and updates the tutorial to demonstrate how to read the keys and pass them into the constructor.

# To Test
1. Requires the workbench with globus auth.
2. Create an application with this spec
3. Launch and open up the notebook under work/tutorials called _1 - Introduction_
4. Observe the second cell that contains the steps to read the keys from disk and the third cell which passes them into the Forge constructor

