### PR TITLE
Add "ports" section to JupyterLab spec

### DIFF
--- a/jupyter/jupyterlab.json
+++ b/jupyter/jupyterlab.json
@@ -18,6 +18,13 @@
         "--NotebookApp.token=''"
     ],
     "authRequired": true,
+    "ports": [
+        {
+            "port": 8888,
+            "protocol": "http",
+            "contextPath": "/"
+        }
+    ],
     "repositories": [
 		{
 			"type": "git",


### PR DESCRIPTION
I noticed that this spec was missing a port, so no endpoint link was given after it started up.