### PR TITLE
Add PostGIS + Geostreams + Geodashboard

### DIFF
--- a/geostreams/geodashboard.json
+++ b/geostreams/geodashboard.json
@@ -1,0 +1,52 @@
+{
+    "key": "geodashboard",
+    "label": "Geodashboard",
+    "logo": "https://github.com/nds-org/ndslabs/raw/develop/gui/asset/png/logos/ndslabs-badge.png",
+    "maintainer": "lambert8@illinois.edu",
+    "image": {
+        "registry": "",
+        "name": "ndslabs/geodashboard",
+        "tags": []
+    },
+    "display": "stack",
+    "access": "external",
+    "depends": [
+        {
+            "key": "geostreams",
+            "required": true
+        },
+        {
+            "key": "postgis",
+            "required": true
+        }
+    ],
+    "config": [
+        {
+            "name": "GEOSTREAMS_URL",
+            "label": "Geostreams URL",
+            "canOverride": true
+        }
+    ],
+    "ports": [
+        {
+            "port": 80,
+            "protocol": "http",
+            "contextPath": "/geodashboard/"
+        }
+    ],
+    "readinessProbe": {
+        "type": "",
+        "path": "",
+        "port": 0,
+        "initialDelay": 0,
+        "timeout": 0
+    },
+    "resourceLimits": {
+        "cpuMax": 500,
+        "cpuDefault": 100,
+        "memMax": 1000,
+        "memDefault": 50
+    },
+    "securityContext": {},
+    "authRequired": true
+}

--- a/geostreams/geostreams.json
+++ b/geostreams/geostreams.json
@@ -1,0 +1,77 @@
+{
+    "key": "geostreams",
+    "label": "Geostreams API",
+    "logo": "https://github.com/nds-org/ndslabs/raw/develop/gui/asset/png/logos/ndslabs-badge.png",
+    "maintainer": "lambert8@illinois.edu",
+    "image": {
+        "registry": "",
+        "name": "ndslabs/geostreams",
+        "tags": [
+            "latest"
+        ]
+    },
+    "display": "stack",
+    "access": "external",
+    "depends": [
+        {
+            "key": "postgis",
+            "required": true
+        }
+    ],
+    "config": [
+        {
+            "name": "APPLICATION_SECRET",
+            "value": "MY_APPLICATION_SECRET",
+            "label": "Application Secret",
+            "canOverride": true
+        },
+        {
+            "name": "POSTGRES_HOST",
+            "label": "PostgreSQL Host",
+            "canOverride": true
+        },
+        {
+            "name": "POSTGRES_PORT",
+            "value": "5432",
+            "label": "PostgreSQL Port",
+            "canOverride": true
+        },
+        {
+            "name": "POSTGRES_USER",
+            "label": "PostgreSQL User",
+            "useFrom": "postgis.POSTGRES_USER"
+        },
+        {
+            "name": "POSTGRES_PASSWORD",
+            "label": "PostgreSQL Password",
+            "useFrom": "postgis.POSTGRES_PASSWORD"
+        },
+        {
+            "name": "POSTGRES_DB",
+            "label": "PostgreSQL Database",
+            "useFrom": "postgis.POSTGRES_DB"
+        }
+    ],
+    "ports": [
+        {
+            "port": 9000,
+            "protocol": "http",
+            "contextPath": "/"
+        }
+    ],
+    "readinessProbe": {
+        "type": "",
+        "path": "",
+        "port": 0,
+        "initialDelay": 0,
+        "timeout": 0
+    },
+    "resourceLimits": {
+        "cpuMax": 500,
+        "cpuDefault": 100,
+        "memMax": 1000,
+        "memDefault": 50
+    },
+    "securityContext": {},
+    "authRequired": true
+}

--- a/geostreams/postgis.json
+++ b/geostreams/postgis.json
@@ -1,0 +1,72 @@
+{
+    "key": "postgis",
+    "label": "PostGIS",
+    "description": "GIS-centric Relational database platform",
+    "logo": "https://github.com/nds-org/ndslabs/raw/develop/gui/asset/png/logos/postgres-logo.png",
+    "image": {
+        "registry": "",
+        "name": "mdillon/postgis",
+        "tags": [
+            "9.5"
+        ]
+    },
+    "display": "stack",
+    "access": "internal",
+    "config": [
+        {
+            "name": "POSTGRES_PASSWORD",
+            "value": "geostreams",
+            "label": "Password",
+            "isPassword": true,
+            "canOverride": true
+        },
+        {
+            "name": "POSTGRES_USER",
+            "value": "postgres",
+            "label": "Username",
+            "canOverride": true
+        },
+        {
+            "name": "POSTGRES_DB",
+            "value": "geostreams",
+            "label": "Database Name",
+            "canOverride": true
+        }
+    ],
+    "ports": [
+        {
+            "port": 5432,
+            "protocol": "tcp"
+        }
+    ],
+    "repositories": [
+        {
+            "url": "https://github.com/postgres/postgres",
+            "type": "git"
+        }
+    ],
+    "readinessProbe": {
+        "type": "tcp",
+        "path": "",
+        "port": 5432,
+        "initialDelay": 30,
+        "timeout": 500
+    },
+    "volumeMounts": [
+        {
+            "mountPath": "/var/lib/postgresql/data"
+        }
+    ],
+    "resourceLimits": {
+        "cpuMax": 200,
+        "cpuDefault": 100,
+        "memMax": 1000,
+        "memDefault": 50
+    },
+    "tags": [
+        "25"
+    ],
+    "info": "https://nationaldataservice.atlassian.net/wiki/display/NDSC/PostgreSQL",
+    "securityContext": {},
+    "authRequired": true
+}


### PR DESCRIPTION
## How to Test
1. Add Geodashboard application from catalog
2. Before starting up, edit PostGIS application
    * Set username to `postgres`
    * Set password to any random string
    * Set database name to `geostreams`
3. Before starting up, edit Geostreams application
    * Set Postgres Host / Port to point at PostGIS service
    * e.g. `$(S12345_POSTGIS_SERVICE_HOST)` where `S12345` is your stack's id
4. Before starting up, edit Geodashboard application
    * Set GEOSTREAMS_URL to point at Geostreams service
    * e.g. `http://$(S12345_GEOSTREAMS_SERVICE_HOST):$(S12345_GEOSTREAMS_SERVICE_PORT)` where `S12345` is your stack's id
5. Start up Geodashboard application
    * NOTE: First startup sometimes does not work, but stopping and starting application again seems to fix things
6. Once Geodashboard application is online, launch a console and import sensor data into PostGIS