### PR TITLE
Add DataWolf application

### DIFF
--- a/datawolf/datawolf.json
+++ b/datawolf/datawolf.json
@@ -1,0 +1,144 @@
+{
+    "key": "datawolf",
+    "label": "DataWolf",
+    "logo": "https://github.com/nds-org/ndslabs/raw/develop/gui/asset/png/logos/ndslabs-badge.png",
+    "maintainer": "lambert8@illinois.edu",
+    "image": {
+        "registry": "",
+        "name": "ncsa/datawolf",
+        "tags": [
+            "4.4.0"
+        ]
+    },
+    "display": "stack",
+    "access": "external",
+    "depends": [
+        {
+            "key": "postgres",
+            "required": true
+        }
+    ],
+    "config": [
+        {
+            "name": "DB_SOURCE_URL",
+            "value": "jdbc:postgresql://postgres/datawolf",
+            "label": "Database Source URL",
+            "canOverride": true
+        },
+        {
+            "name": "DATAWOLF_ADMINS",
+            "value": "admin@example.com",
+            "label": "Datawolf Admins",
+            "canOverride": true
+        },
+        {
+            "name": "DATAWOLF_USE_AUTH",
+            "value": "false",
+            "label": "Datawolf Use Auth",
+            "canOverride": true
+        },
+        {
+            "name": "DB_CLASS_NAME",
+            "value": "org.postgresql.ds.PGSimpleDataSource",
+            "label": "Database Classname",
+            "canOverride": true
+        },
+        {
+            "name": "DB_DIALECT",
+            "label": "Database Dialect",
+            "canOverride": true
+        },
+        {
+            "name": "DB_MAX_POOLSIZE",
+            "value": "100",
+            "label": "Database Max Pool Size",
+            "canOverride": true
+        },
+        {
+            "name": "DB_IDLE_TIMEOUT",
+            "value": "30000",
+            "label": "Database Idle Timeout",
+            "canOverride": true
+        },
+        {
+            "name": "DB_USER",
+            "value": "datawolf",
+            "label": "Database User",
+            "canOverride": true
+        },
+        {
+            "name": "DB_PASSWORD",
+            "value": "datawolf",
+            "label": "Database Password",
+            "canOverride": true
+        },
+        {
+            "name": "ENGINE_STORELOGS",
+            "value": "false",
+            "label": "Engine Store Logs",
+            "canOverride": true
+        },
+        {
+            "name": "ENGINE_TIMEOUT",
+            "value": "3600",
+            "label": "Engine Timeout",
+            "canOverride": true
+        },
+        {
+            "name": "ENGINE_EXTRALOCALEXECUTOR",
+            "value": "1",
+            "label": "Engine Local Executor",
+            "canOverride": true
+        },
+        {
+            "name": "ENGINE_EXTRALOCALEXECUTOR_THREADS",
+            "value": "8",
+            "label": "Engine Local Executor Threads",
+            "canOverride": true
+        },
+        {
+            "name": "ENGINE_PAGESIZE",
+            "value": "250",
+            "label": "Engine Page Size",
+            "canOverride": true
+        },
+        {
+            "name": "EXECUTOR_DEBUG",
+            "value": "false",
+            "label": "Executor Debug",
+            "canOverride": true
+        },
+        {
+            "name": "LOG",
+            "label": "Log",
+            "canOverride": true
+        }
+    ],
+    "ports": [
+        {
+            "port": 8888,
+            "protocol": "http",
+            "contextPath": "/"
+        }
+    ],
+    "readinessProbe": {
+        "type": "",
+        "path": "",
+        "port": 0,
+        "initialDelay": 0,
+        "timeout": 0
+    },
+    "volumeMounts": [
+        {
+            "mountPath": "/home/datawolf/data"
+        }
+    ],
+    "resourceLimits": {
+        "cpuMax": 500,
+        "cpuDefault": 100,
+        "memMax": 1000,
+        "memDefault": 50
+    },
+    "securityContext": {},
+    "authRequired": true
+}

--- a/datawolf/datawolf.json
+++ b/datawolf/datawolf.json
@@ -118,7 +118,7 @@
         {
             "port": 8888,
             "protocol": "http",
-            "contextPath": "/"
+            "contextPath": "/datawolf/editor"
         }
     ],
     "readinessProbe": {

--- a/datawolf/datawolf.json
+++ b/datawolf/datawolf.json
@@ -91,7 +91,7 @@
             "canOverride": true
         },
         {
-            "name": "ENGINE_EXTRALOCALEXECUTOR_THREADS",
+            "name": "ENGINE_LOCALEXECUTORTHREADS",
             "value": "8",
             "label": "Engine Local Executor Threads",
             "canOverride": true


### PR DESCRIPTION
~~Needs testing / sanity check.. are there docs or test steps for this somewhere?~~

## How to Test
1. Add DataWolf application from catalog
2. Before starting up, edit PostgreSQL application
    * Set username/password/database name to `datawolf`
3. Before starting up, edit DataWolf application
    * Set Database Source URL to point at PostgreSQL
    * e.g. `jdbc:postgresql://$(S12345_POSTGRES_SERVICE_HOST)/datawolf` where `S12345` is your stack's id
    * Set Initial Admins to an email address (ideally, use the email of your test user that will soon sign up)
4. Start up DataWolf application
5. Once DataWolf application is online, click Open to navigate to DataWolf Editor
6. Sign Up a test user and Log in to the system
    * You should be able to see and interact with the DataWolf Editor